### PR TITLE
Added an ascMain for the library

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "assemblyscript-regex",
   "version": "0.1.0",
   "description": "A regex engine built with AssemblyScript",
-  "main": "assembly/index.ts",
+  "ascMain": "assembly/index.ts",
   "scripts": {
     "test": "npm run asbuild:untouched && npm run prettier:check && jest __tests__",
     "test:suite": "npm run asbuild:untouched && jest __spec_tests__ --reporter=jest-summary-reporter",


### PR DESCRIPTION
Per the docs in the library: https://www.assemblyscript.org/compiler.html#command-line-options

`ascMain` is the name for an AssemblyScript entrypoint. I think the library would still work even if you didn't have this, since you have an `assembly/index.ts`. But I guess this is more for convention haha! :smile: :tada: 

Also, again, AMAZING library! I also made a quick little Compute@Edge Serverless demo using it, and it's working great! https://as-compute-regex.edgecompute.app/ :smile: :tada: 