### PR TITLE
Upgrade to AssemblyScript v0.18

### DIFF
--- a/asconfig.json
+++ b/asconfig.json
@@ -16,5 +16,7 @@
       "noAssert": false
     }
   },
-  "options": {}
+  "options": {
+    "exportRuntime": true
+  }
 }

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -16,12 +16,7 @@ wasmModule = loader.instantiateSync(fs.readFileSync("./build/untouched.wasm"), {
 
 // the executeRegExp exported function is ex
 function executeRegex(regexStr, valueStr, untilNull = false) {
-  const {
-    executeRegExp,
-    __newString,
-    __pin,
-    __unpin,
-  } = wasmModule.exports;
+  const { executeRegExp, __newString, __pin, __unpin } = wasmModule.exports;
 
   // create the regexp
   const regexPtr = __pin(__newString(regexStr));

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -1,6 +1,6 @@
 global.TextDecoder = require("text-encoding").TextDecoder;
 const fs = require("fs");
-const loader = require("@assemblyscript/loader/umd/index");
+const loader = require("@assemblyscript/loader");
 
 const Benchmark = require("benchmark");
 const suite = new Benchmark.Suite();
@@ -8,10 +8,8 @@ const suite = new Benchmark.Suite();
 wasmModule = loader.instantiateSync(fs.readFileSync("./build/untouched.wasm"), {
   env: {
     log: () => {
-      const { __getString, __release } = wasmModule.exports;
-      str = __getString(strPtr);
-      console.log(str);
-      __release(strPtr);
+      const { __getString } = wasmModule.exports;
+      console.log(__getString(strPtr));
     },
   },
 });
@@ -21,16 +19,15 @@ function executeRegex(regexStr, valueStr, untilNull = false) {
   const {
     executeRegExp,
     __newString,
-    __retain,
-    __release,
+    __pin,
+    __unpin,
   } = wasmModule.exports;
 
   // create the regexp
-  const regexPtr = __retain(__newString(regexStr));
-  const strPtr = __retain(__newString(valueStr));
+  const regexPtr = __pin(__newString(regexStr));
+  const strPtr = __newString(valueStr);
   executeRegExp(regexPtr, strPtr, untilNull ? -1 : 5);
-  __release(regexPtr);
-  __release(strPtr);
+  __unpin(regexPtr);
 }
 
 // add tests

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "author": "colin.eberhardt@gmail.com",
   "license": "MIT",
   "devDependencies": {
-    "@assemblyscript/loader": "^0.17.5",
+    "@assemblyscript/loader": "^0.18.0",
     "@types/node": "^14.14.13",
-    "assemblyscript": "0.17.5",
+    "assemblyscript": "^0.18.0",
     "benchmark": "^2.1.4",
     "jest": "^26.6.3",
     "jest-summary-reporter": "0.0.2",


### PR DESCRIPTION
This PR upgrades AS to soon-to-be-released v0.18. Makes the necessary changes to the runtime interface so it passes the test suite and benchmark.

A few strange things seemed to be going on:
* Prettier says all files are invalid, probably due to CRLF on Windows, so I had to disable it locally
* `could not parse test case 28`
* `Package subpath './umd/index.js' is not defined by "exports"` in node v15, so I needed to change a `require`