### PR TITLE
Throw an explicit error when there is nothing to repeat

### DIFF
--- a/assembly/__tests__/regex.spec.ts
+++ b/assembly/__tests__/regex.spec.ts
@@ -155,3 +155,11 @@ describe("use cases", () => {
     expect(match.matches[3]).toBe("com");
   });
 });
+
+describe("error cases", () => {
+  it("throws an explicit error when there is nothing to repeat", () => {
+    expect(() => {
+      let foo = new RegExp("*m", ""); // eslint-disable-line no-invalid-regexp
+    }).toThrow("Invalid regular expression: Nothing to repeat");
+  });
+});

--- a/assembly/parser/parser.ts
+++ b/assembly/parser/parser.ts
@@ -251,6 +251,10 @@ export class Parser {
           nodes.push(this.parseCharacter());
         }
       } else if (isQuantifier(token)) {
+        if (nodes.length === 0) {
+          throw new Error("Invalid regular expression: Nothing to repeat");
+        }
+
         const expression = nodes.pop();
         const quantifier = this.eatToken();
         nodes.push(new RepetitionNode(expression, quantifier, this.isGreedy()));


### PR DESCRIPTION
Hi!

Thanks for this cool library!

If you do not specify anything to "repeat", such as `"*m"`, here is what we have currently:
```
 [Message]: Array is empty
   [Stack]: RuntimeError: unreachable
            at ~lib/array/Array<assembly/parser/node/Node>#pop (<anonymous>:wasm-function[100]:0x2504)
            at assembly/parser/parser/Parser#parseSequence (<anonymous>:wasm-function[133]:0x2d84)
            at assembly/parser/parser/Parser#toAST (<anonymous>:wasm-function[134]:0x2dff)
            at assembly/parser/parser/Parser.toAST (<anonymous>:wasm-function[135]:0x2e10)
            at assembly/regexp/RegExp#constructor (<anonymous>:wasm-function[250]:0x4b00)
            at start:assembly/__tests__/regex.spec~anonymous|7~anonymous|0 (<anonymous>:wasm-function[412]:0x7374)
            at node_modules/@as-pect/assembly/assembly/internal/call/__call (<anonymous>:wasm-function[416]:0x73f1)
```

This is the behavior in JS:
```
> new RegExp('*m')
Uncaught SyntaxError: Invalid regular expression: /*m/: Nothing to repeat
```

Couple notes with this PR:
* it seems that the assertion on error message isn't actually used (i.e. if I remove the "if" the tests are still green)
* as you can see, in JS they repeat the expression: I wasn't quite sure if we wanted to keep a reference on the `input` in the `Parser`'s constructor and reproduce this behavior

Let me know what you think, happy to update the code in any way!