### PR TITLE
decorate all global variable with @lazy

### DIFF
--- a/assembly/char.ts
+++ b/assembly/char.ts
@@ -1,3 +1,6 @@
+// @ts-ignore
+// prettier-ignore
+@lazy
 export const enum Char {
   None = -1,
   HorizontalTab = 0x09,

--- a/assembly/nfa/matcher.ts
+++ b/assembly/nfa/matcher.ts
@@ -10,6 +10,9 @@ import {
 import { Flags } from "../regexp";
 import { Range } from "../util";
 
+// @ts-ignore
+// prettier-ignore
+@lazy
 const enum MatcherType {
   Character,
   CharacterRange,
@@ -17,7 +20,9 @@ const enum MatcherType {
   CharacterClass,
 }
 
-let _flags: Flags;
+// @ts-ignore
+@lazy
+  let _flags: Flags;
 
 export class Matcher {
   constructor(readonly type: MatcherType) {}
@@ -93,9 +98,20 @@ export class CharacterMatcher extends Matcher {
   }
 }
 
-const LOWERCASE_LETTERS = new Range(Char.a, Char.z);
-const UPPERCASE_LETTERS = new Range(Char.A, Char.Z);
-const UPPER_LOWER_OFFSET = Char.a - Char.A;
+// @ts-ignore
+// prettier-ignore
+@lazy
+  const LOWERCASE_LETTERS = new Range(Char.a, Char.z);
+
+// @ts-ignore
+// prettier-ignore
+@lazy
+  const UPPERCASE_LETTERS = new Range(Char.A, Char.Z);
+
+// @ts-ignore
+// prettier-ignore
+@lazy
+  const UPPER_LOWER_OFFSET = Char.a - Char.A;
 
 export class CharacterRangeMatcher extends Matcher {
   private ranges: Range[];

--- a/assembly/nfa/nfa.ts
+++ b/assembly/nfa/nfa.ts
@@ -15,6 +15,9 @@ import { Char } from "../char";
 import { Matcher } from "./matcher";
 import { Flags } from "../regexp";
 
+// @ts-ignore
+// prettier-ignore
+@lazy
 export enum MatchResult {
   // a match has occurred - which is a signal to consume a character
   Match,
@@ -24,7 +27,10 @@ export enum MatchResult {
   Ignore,
 }
 
-let _stateId: u32 = 0;
+// @ts-ignore
+// prettier-ignore
+@lazy
+  let _stateId: u32 = 0;
 
 /* eslint @typescript-eslint/no-empty-function: ["error", { "allow": ["constructors", "methods"] }] */
 export class State {

--- a/assembly/parser/node.ts
+++ b/assembly/parser/node.ts
@@ -1,6 +1,9 @@
 import { Char } from "../char";
 import { replaceAtIndex } from "../util";
 
+// @ts-ignore
+// prettier-ignore
+@lazy
 export const enum NodeType {
   AST,
   Assertion,
@@ -15,7 +18,10 @@ export const enum NodeType {
   Group,
 }
 
-const emptyNodeArray = new Array<Node>();
+// @ts-ignore
+// prettier-ignore
+@lazy
+  const emptyNodeArray = new Array<Node>();
 
 export abstract class Node {
   constructor(public type: NodeType) {}
@@ -210,7 +216,10 @@ export class AlternationNode extends Node {
   }
 }
 
-let _id = 0;
+// @ts-ignore
+// prettier-ignore
+@lazy
+  let _id = 0;
 
 export class GroupNode extends Node {
   constructor(

--- a/assembly/parser/walker.ts
+++ b/assembly/parser/walker.ts
@@ -37,7 +37,10 @@ export function walker(ast: AST, visitor: (node: NodeVisitor) => void): void {
 // range quantifiers are implemented via 'expansion', which significantly
 // increases the size of the AST. This imposes a hard limit to prevent
 // memory-related issues
-const QUANTIFIER_LIMIT = 1000;
+// @ts-ignore
+// prettier-ignore
+@lazy
+  const QUANTIFIER_LIMIT = 1000;
 
 function parentAsConcatNode(visitor: NodeVisitor): ConcatenationNode {
   let concatNode: ConcatenationNode | null = null;

--- a/assembly/regexp.ts
+++ b/assembly/regexp.ts
@@ -69,7 +69,10 @@ export class Match {
   }
 }
 
-let gm = new Array<GroupStartMarkerState>();
+// @ts-ignore
+// prettier-ignore
+@lazy
+  let gm = new Array<GroupStartMarkerState>();
 
 export class Flags {
   global: bool = false;


### PR DESCRIPTION
Same as https://github.com/ColinEberhardt/assemblyscript-temporal/pull/40

**Additional Notes**
Tried everything to make prettier happy, but seems it still has problems with decorated enums even with `// prettier-ignore` :\